### PR TITLE
チャットメッセージのvalidatorを削除 fixes #7

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,6 @@ io.on('connection', function(socket){
   });
 
   socket.on('chat message', function(msg){
-    msg = validator.escape(msg);
     var msgClass = "msg", question = false;
 
     if (msg === '') {


### PR DESCRIPTION
Vue.jsだとバインディングの際にHTMLエスケープしてくれるので，わざわざvalidatorはいらないっぽい．
（名前の部分はどういう仕様なのかよく把握してないので未着手）
